### PR TITLE
typo + fix a possible NaN in Logic.matchLikelihood

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # sbt in Action Example code
-This project contains the example code for sbt in Action.   The code takes the form of a series of sbt builds for a sophisticated website called preowned-kittens.com that handles the resale of pet kittens.    The website attempts to find ideal owners by matching buyer survey questions to know statistics of happy pet owners, and behavior characteristics of the kittens.
+This project contains the example code for sbt in Action.   The code takes the form of a series of sbt builds for a sophisticated website called preowned-kittens.com that handles the resale of pet kittens.    The website attempts to find ideal owners by matching buyer survey questions to known statistics of happy pet owners, and behavior characteristics of the kittens.
 
 The project is split into directories by chapter, and then optionally by section.    The final build is located under a directory called `final` for those who wish to see/use the completed product.
 

--- a/chapter2/src/main/scala/logic.scala
+++ b/chapter2/src/main/scala/logic.scala
@@ -3,10 +3,10 @@ package org.preownedkittens
 object Logic {
   /** Determines the match likelihood and returns % match. */
   def matchLikelihood(kitten: Kitten, buyer: BuyerPreferences): Double = {
-    val matches = buyer.attributes map { attribute => 
+    val matches = buyer.attributes map { attribute =>
       kitten.attributes contains attribute
     }
     val nums = matches map { b => if(b) 1.0 else 0.0 }
-    nums.sum / nums.length
+    if (nums.length > 0) nums.sum / nums.length else 0.0
   }
 }

--- a/chapter2/src/test/scala/LogicSpec.scala
+++ b/chapter2/src/test/scala/LogicSpec.scala
@@ -12,8 +12,14 @@ object LogicSpec extends Specification {
     "be 0% when no attributes match" in {
       val tabby = Kitten(1, List("male", "tabby"))
       val prefs = BuyerPreferences(List("female", "calico"))
-      val result = Logic.matchLikelihood(tabby, prefs) 
+      val result = Logic.matchLikelihood(tabby, prefs)
       result must beLessThan(0.001)
+    }
+    "correctly handle an empty BuyerPreferences" in {
+      val tabby = Kitten(1, List("male", "tabby"))
+      val prefs = BuyerPreferences(List())
+      val result = Logic.matchLikelihood(tabby, prefs)
+      result.isNaN mustEqual false
     }
   }
 }


### PR DESCRIPTION
I'm not sure if you'll want this change, but i felt that I should point it out. If you take this pull request to Chapter2, I can replicate it in the other chapter areas - since it appears in all of them.
